### PR TITLE
perf: use process-fast

### DIFF
--- a/esbuild.inject.js
+++ b/esbuild.inject.js
@@ -1,2 +1,2 @@
 export let Buffer = require('buffer').Buffer
-export let process = require('process/browser')
+export let process = require('process-fast')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "events": "^3.3.0",
     "get-browser-rtc": "^1.1.0",
     "pako": "^2.0.4",
-    "process": "^0.11.10",
+    "process-fast": "^1.0.0",
     "random-string": "^0.2.0",
     "simple-peer": "^9.11.1",
     "stream-browserify": "^3.0.0"


### PR DESCRIPTION
this is a very quick and easy fix for major performance bottlenecks caused by the `process` until #1 is resolved, as it uses queueMicrotask instead of setTimeout