### PR TITLE
On a network change, re-create the peer gracefully when it closes

### DIFF
--- a/examples/basic-video-chat/p2pcf.js
+++ b/examples/basic-video-chat/p2pcf.js
@@ -2253,7 +2253,8 @@ var P2PCF = class extends import_events.default {
       lastProcessedReceivedDataTimestamps,
       packageReceivedFromPeers,
       stunIceServers,
-      turnIceServers
+      turnIceServers,
+      peersToRecreateOnClose
     } = this;
     const [localSessionId, , localSymmetric] = localPeerData;
     const now = new Date().getTime();
@@ -2280,6 +2281,8 @@ var P2PCF = class extends import_events.default {
       }
       if (isPeerA) {
         if (peers.has(remoteSessionId))
+          continue;
+        if (peersToRecreateOnClose.has(remoteSessionId))
           continue;
         if (!remotePackage)
           continue;
@@ -2361,7 +2364,7 @@ var P2PCF = class extends import_events.default {
         }
         peer.signal({ type: "offer", sdp: remoteSdp });
       } else {
-        if (!peers.has(remoteSessionId)) {
+        if (!peers.has(remoteSessionId) && !peersToRecreateOnClose.has(remoteSessionId)) {
           lastProcessedReceivedDataTimestamps.set(
             remoteSessionId,
             remoteDataTimestamp

--- a/examples/basic-video-chat/p2pcf.js
+++ b/examples/basic-video-chat/p2pcf.js
@@ -1972,6 +1972,18 @@ var randomstring = (len) => {
   const str = bytes.reduce((accum, v) => accum + String.fromCharCode(v), "");
   return btoa(str).replaceAll("=", "");
 };
+var removeInPlace = (a, condition) => {
+  let i = 0;
+  let j = 0;
+  while (i < a.length) {
+    const val = a[i];
+    if (!condition(val, i, a))
+      a[j++] = val;
+    i++;
+  }
+  a.length = j;
+  return a;
+};
 var ua = window.navigator.userAgent;
 var iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
 var webkit = !!ua.match(/WebKit/i);
@@ -2065,7 +2077,6 @@ var P2PCF = class extends import_events.default {
     this.dataTimestamp = null;
     this.lastPackages = null;
     this.lastProcessedReceivedDataTimestamps = /* @__PURE__ */ new Map();
-    this.peersToRecreateOnClose = /* @__PURE__ */ new Set();
     this.packageReceivedFromPeers = /* @__PURE__ */ new Set();
     this.startedAtTimestamp = null;
     this.workerUrl = options.workerUrl || "https://p2pcf.minddrop.workers.dev";
@@ -2084,8 +2095,8 @@ var P2PCF = class extends import_events.default {
     this.dtlsCert = null;
     this.udpEnabled = null;
     this.isSymmetric = null;
-    this.reflexiveIps = null;
     this.dtlsFingerprint = null;
+    this.reflexiveIps = /* @__PURE__ */ new Set();
     this.isSending = false;
     this.finished = false;
     this.nextStepTime = -1;
@@ -2161,15 +2172,10 @@ var P2PCF = class extends import_events.default {
       let includePackages = false;
       if (expired || packagesChanged || finish) {
         this.dataTimestamp = now;
-        for (let i = 0; i < packages.length; i++) {
-          const sentAt = packages[i][packages[i].length - 2];
-          if (now - sentAt > 60 * 1e3) {
-            packages[i] = null;
-          }
-        }
-        while (packages.indexOf(null) >= 0) {
-          packages.splice(packages.indexOf(null), 1);
-        }
+        removeInPlace(packages, (pkg) => {
+          const sentAt = pkg[pkg.length - 2];
+          return now - sentAt > 60 * 1e3;
+        });
         includePackages = true;
       }
       if (finish) {
@@ -2253,8 +2259,7 @@ var P2PCF = class extends import_events.default {
       lastProcessedReceivedDataTimestamps,
       packageReceivedFromPeers,
       stunIceServers,
-      turnIceServers,
-      peersToRecreateOnClose
+      turnIceServers
     } = this;
     const [localSessionId, , localSymmetric] = localPeerData;
     const now = new Date().getTime();
@@ -2281,8 +2286,6 @@ var P2PCF = class extends import_events.default {
       }
       if (isPeerA) {
         if (peers.has(remoteSessionId))
-          continue;
-        if (peersToRecreateOnClose.has(remoteSessionId))
           continue;
         if (!remotePackage)
           continue;
@@ -2364,7 +2367,7 @@ var P2PCF = class extends import_events.default {
         }
         peer.signal({ type: "offer", sdp: remoteSdp });
       } else {
-        if (!peers.has(remoteSessionId) && !peersToRecreateOnClose.has(remoteSessionId)) {
+        if (!peers.has(remoteSessionId)) {
           lastProcessedReceivedDataTimestamps.set(
             remoteSessionId,
             remoteDataTimestamp
@@ -2497,25 +2500,13 @@ var P2PCF = class extends import_events.default {
         newReflexiveIps,
         newDtlsFingerprint
       ] = await this._getNetworkSettings(this.dtlsCert);
-      let retainedAnyReflexiveIps = false;
-      for (const oldIp of this.reflexiveIps) {
-        for (const newIp of newReflexiveIps) {
-          if (oldIp === newIp)
-            retainedAnyReflexiveIps = true;
-        }
-      }
-      if (newUdpEnabled !== this.udpEnabled || newIsSymmetric !== this.isSymmetric || newDtlsFingerprint !== this.dtlsFingerprint || !retainedAnyReflexiveIps) {
-        this.packages.length = 0;
-        for (const peer of this.peers.values()) {
-          this.peersToRecreateOnClose.add(peer.id);
-        }
+      if (newUdpEnabled !== this.udpEnabled || newIsSymmetric !== this.isSymmetric || newDtlsFingerprint !== this.dtlsFingerprint || !![...newReflexiveIps].find((ip) => ![...this.reflexiveIps].find((ip2) => ip === ip2)) || !![...reflexiveIps].find((ip) => ![...newReflexiveIps].find((ip2) => ip === ip2))) {
         this.dataTimestamp = null;
-        this.lastPackages = null;
-        this.udpEnabled = newUdpEnabled;
-        this.isSymmetric = newIsSymmetric;
-        this.reflexiveIps = newReflexiveIps;
-        this.dtlsFingerprint = newDtlsFingerprint;
       }
+      this.udpEnabled = newUdpEnabled;
+      this.isSymmetric = newIsSymmetric;
+      this.reflexiveIps = newReflexiveIps;
+      this.dtlsFingerprint = newDtlsFingerprint;
     }, this.networkChangePollIntervalMs);
     this._step = this._step.bind(this);
     this.stepInterval = setInterval(this._step, 500);
@@ -2528,14 +2519,7 @@ var P2PCF = class extends import_events.default {
     const { packageReceivedFromPeers, packages, peers } = this;
     if (!peers.has(peer.id))
       return;
-    for (let i = 0; i < packages.length; i++) {
-      if (packages[i][0] === peer.id) {
-        packages[i] = null;
-      }
-    }
-    while (packages.indexOf(null) >= 0) {
-      packages.splice(packages.indexOf(null), 1);
-    }
+    removeInPlace(packages, (pkg) => pkg[0] === peer.id);
     packageReceivedFromPeers.delete(peer.id);
     peers.delete(peer.id);
     if (destroy) {
@@ -2729,6 +2713,7 @@ var P2PCF = class extends import_events.default {
   _wireUpCommonPeerEvents(peer) {
     peer.on("connect", () => {
       this.emit("peerconnect", peer);
+      removeInPlace(this.packages, (pkg) => pkg[0] === peer.id);
       this._updateConnectedSessions();
     });
     peer.on("data", (data) => {
@@ -2756,15 +2741,10 @@ var P2PCF = class extends import_events.default {
         this._checkForSignalOrEmitMessage(peer, data);
       }
     });
-    peer.on("error", () => {
-      this._removePeer(peer);
-      this._updateConnectedSessions();
+    peer.on("error", (err) => {
+      console.warn(err);
     });
     peer.on("close", () => {
-      if (this.peersToRecreateOnClose.has(peer.id)) {
-        this.lastProcessedReceivedDataTimestamps.delete(peer.id);
-        this.peersToRecreateOnClose.delete(peer.id);
-      }
       this._removePeer(peer);
       this._updateConnectedSessions();
     });


### PR DESCRIPTION
Instead of forcibly disconnecting all peers on a network change, mark all peers as needing a restart. This results in no forced disconnects in the case of false positives but will also cause the peer to come back online again once it closes. The downside of this is there will be a bunch of dead peers floating around if IPs change benignly and any of the active peers disconnect eventually, since they'll be re-created.