### PR TITLE
critical: handle destroy state correctly

### DIFF
--- a/src/p2pcf.js
+++ b/src/p2pcf.js
@@ -790,6 +790,8 @@ export default class P2PCF extends EventEmitter {
       dtlsFingerprint
     ] = await this._getNetworkSettings(this.dtlsCert)
 
+    if (this.finished) return
+
     this.udpEnabled = udpEnabled
     this.isSymmetric = isSymmetric
     this.reflexiveIps = reflexiveIps


### PR DESCRIPTION
this fixes an issue which would leak step and network intervals, which would accumulate over usage, especially for SPA's

this happened when a p2pcf instance was destroyed promptly after being created